### PR TITLE
support suiup some issue

### DIFF
--- a/SuiContributor/lispking/README.md
+++ b/SuiContributor/lispking/README.md
@@ -1,3 +1,8 @@
 # 贡献跟踪表
 
+### 2025年7月贡献
+- 代码 PR：[优化 suiup 工具：解决版本管理与用户体验问题](https://github.com/MystenLabs/suiup/pull/66)
+- 文章：[优化 suiup 工具 —— 解决版本管理与用户体验](https://learnblockchain.cn/article/18846)
+
+### 2025年6月贡献
 - [Refactor Command Handling and Improve suiup Installation Workflow](https://github.com/MystenLabs/suiup/pull/50)


### PR DESCRIPTION
- **支持在同一二进制文件下切换不同 nightly 版本**
当前支持从不同分支安装多个 nightly 版本（如 mvr、sui、walrus），但无法方便地在这些版本间切换。需添加功能，支持用户在同一二进制文件的不同 nightly 版本间切换。

- **修复新版本更新警告问题**
在使用新版本的 suiup 时，出现错误警告，提示从 v0.0.4 更新到 v0.0.3（版本号错误）。需修复警告逻辑，确保显示正确的版本更新信息，并引导用户运行 suiup self update 更新到最新版本。

- **改进不存在版本的错误提示**
当前 suiup install 命令支持网络、版本或网络-版本组合，但可能因版本未发布（如 v1.53 仅在 devnet 可用，testnet 未发布）导致奇怪的错误信息。需改进逻辑，检查版本是否存在，并列出可用版本，引导用户使用正确命令，如 `suiup install sui@devnet-1.53.0`。

- **为所有命令添加更新警告**
在所有 suiup 命令中添加更新提示，提醒用户检查并更新到最新版本。

- **上述issue对应的文章解读**
[优化 suiup 工具：解决版本管理与用户体验问题](https://learnblockchain.cn/article/18846)

